### PR TITLE
UDP Reset 

### DIFF
--- a/EVAL-KIT/FeatherS2/commands_list.md
+++ b/EVAL-KIT/FeatherS2/commands_list.md
@@ -5,6 +5,9 @@ There is an HTTP server runing on port 80 that will open up a web gui. You can u
 ### TCP Connection
 There is a TCP server running on port 23 (Telnet). This has two uses: direct communication with tile and sending @commands wirelessly.
 
+### UDP Connection
+There is a UDP server running on port 5280. This has only a single use: sending the `@reset` command below.
+
 ### Serial Connection
 Using a wired connection over the USB-C port on the feather you can send the @commands listed below.
 


### PR DESCRIPTION
This branch adds a UDP socket that handles the `@reset` command. This is exceptionally useful when the TCP socket cannot be opened and the Feather needs to be reset. This has been necessary to have an unattended installation running for more than a couple of days without requiring a manual power cycle of the entire eval kit. This does not fundamentally change the Feather's behavior, but simply adds an additional (optional) recovery method.

See #15